### PR TITLE
Change python requirement, update build #

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,14 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1 
 
 requirements:
   host:
-    - python >=3.10
+    - python >=3.8
     - pip
   run:
-    - python >=3.10
+    - python >=3.8
     - ele
     - freud >=2.13.1
     - gsd >=3.0


### PR DESCRIPTION
Setting the python requirement to >=3.10 is not necessary, and is causing some issues with packages that depend on this.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
